### PR TITLE
fix: flaky tests improvement

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on:
       - ${{ inputs.codebuild-name || 'codebuild-Hayabusa-E2E' }}-${{ github.run_id }}-${{ github.run_attempt }}
       - image:arm-3.0
-      - instance-size:xlarge # xlarge=32 vCPUs, 64 GiB memory, large=8 vCPUs, 16 GiB memory
+      - instance-size:large # xlarge=32 vCPUs, 64 GiB memory, large=8 vCPUs, 16 GiB memory
 
     strategy:
       matrix:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,7 +3,7 @@ name: Run Hayabusa Tests
 on:
   push:
     branches:
-      - main
+      - fix/flaky-tests
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,7 +3,7 @@ name: Run Hayabusa Tests
 on:
   push:
     branches:
-      - fix/flaky-tests
+      - main
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: vechain/thor
           path: thor
-          ref: ${{ inputs.thor-branch || 'release/hayabusa' }}
+          ref: 'test-miguel/hayabusa'
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,7 +3,7 @@ name: Run Hayabusa Tests
 on:
   push:
     branches:
-      - fix/flaky-tests
+      - main
   pull_request:
   workflow_dispatch:
     inputs:
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: vechain/thor
           path: thor
-          ref: 'test-miguel/hayabusa'
+          ref: ${{ inputs.thor-branch || 'release/hayabusa' }}
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on:
       - ${{ inputs.codebuild-name || 'codebuild-Hayabusa-E2E' }}-${{ github.run_id }}-${{ github.run_attempt }}
       - image:arm-3.0
-      - instance-size:large # xlarge=32 vCPUs, 64 GiB memory, large=8 vCPUs, 16 GiB memory
+      - instance-size:xlarge # xlarge=32 vCPUs, 64 GiB memory, large=8 vCPUs, 16 GiB memory
 
     strategy:
       matrix:

--- a/cmd/network/main.go
+++ b/cmd/network/main.go
@@ -33,7 +33,7 @@ func main() {
 		HighStakingPeriod: 180,
 	}
 
-	client, net, cancel, err := hayabusa.StartNetwork(config)
+	client, net, cancel, err := hayabusa.StartNetwork(nil, config)
 	if err != nil {
 		panic(err)
 	}

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vechain/thor/v2/thorclient"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -161,12 +162,14 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 		return nil, nil, nil, err
 	}
 
-	if err = networkCfg.HealthCheck(0, 2*time.Minute); err != nil {
+	if err = networkCfg.HealthCheck(0, 30*time.Second); err != nil {
 		hayabusaNetwork.StopNetwork()
 
 		cleanupPorts(usedPorts)
 		return nil, nil, nil, fmt.Errorf("health check failed: %w", err)
 	}
+
+	pollingWhileConnectingPeers(t, nodes, config.Nodes)
 
 	// verbose logging for node 0, use node 1 for http (simulation etc.). Amount validated on first line of function
 	client := thorclient.New(nodes[1].GetHTTPAddr())
@@ -320,4 +323,34 @@ func isPortAvailable(port int) bool {
 	}
 	ln.Close()
 	return true
+}
+
+func pollingWhileConnectingPeers(t *testing.T, nodes []node.Config, expectedPeersLen int) []*thorclient.Client {
+	// Polling approach with timeout
+	timeout := time.After(1 * time.Minute)
+	tick := time.Tick(5 * time.Second)
+
+	clients := make([]*thorclient.Client, 0)
+	for {
+		select {
+		case <-timeout:
+			t.Fatal("timed out waiting for nodes to connect")
+		case <-tick:
+			allConnected := true
+			for _, node := range nodes {
+				c := thorclient.New(node.GetHTTPAddr())
+				peers, err := c.Peers()
+				assert.NoError(t, err)
+				if len(peers) != expectedPeersLen {
+					allConnected = false
+					clients = clients[:0]
+					break
+				}
+				clients = append(clients, c)
+			}
+			if allConnected {
+				return clients
+			}
+		}
+	}
 }

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"net"
 	"os"
 	"strconv"
 	"sync"
@@ -266,10 +267,13 @@ func rndPort() int {
 	defer portMutex.Unlock()
 
 	const (
-		minPort = 49152
-		maxPort = 65535
+		minPort     = 49152
+		maxPort     = 65535
+		maxAttempts = 100
 	)
-	for {
+
+	attempts := 0
+	for attempts < maxAttempts {
 		buf := make([]byte, 2)
 		// Ignoring the error for brevity—not recommended in production code!
 		_, _ = rand.Read(buf)
@@ -277,11 +281,25 @@ func rndPort() int {
 		// Convert 2 bytes to a 16-bit number, then mod by the range size.
 		n := int(buf[0])<<8 | int(buf[1])
 		port := minPort + (n % (maxPort - minPort + 1))
-		if !globalUsedPorts[port] {
+
+		// Check if port is not in our global map AND actually available
+		if !globalUsedPorts[port] && isPortAvailable(port) {
+			globalUsedPorts[port] = true
+			return port
+		}
+		attempts++
+	}
+
+	// If we can't find an available port after maxAttempts,
+	// try sequential search starting from minPort
+	for port := minPort; port <= maxPort; port++ {
+		if !globalUsedPorts[port] && isPortAvailable(port) {
 			globalUsedPorts[port] = true
 			return port
 		}
 	}
+
+	panic(fmt.Sprintf("no available ports found in range %d-%d", minPort, maxPort))
 }
 
 // cleanupPorts releases the specified ports back to the global pool
@@ -292,4 +310,15 @@ func cleanupPorts(ports []int) {
 	for _, port := range ports {
 		delete(globalUsedPorts, port)
 	}
+}
+
+// isPortAvailable checks if a port is actually available for binding
+func isPortAvailable(port int) bool {
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return false
+	}
+	ln.Close()
+	return true
 }

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -169,7 +169,12 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 		return nil, nil, nil, fmt.Errorf("health check failed: %w", err)
 	}
 
-	utils.WaitForPeersConnection(t, nodes, config.Nodes-1)
+	err = utils.WaitForPeersConnection(t, nodes, config.Nodes-1)
+	if err != nil {
+		hayabusaNetwork.StopNetwork()
+		cleanupPorts(usedPorts)
+		return nil, nil, nil, err
+	}
 
 	// verbose logging for node 0, use node 1 for http (simulation etc.). Amount validated on first line of function
 	client := thorclient.New(nodes[1].GetHTTPAddr())

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -341,6 +341,7 @@ func pollingWhileConnectingPeers(t *testing.T, nodes []node.Config, expectedPeer
 				c := thorclient.New(node.GetHTTPAddr())
 				peers, err := c.Peers()
 				assert.NoError(t, err)
+				fmt.Printf("LLEGA: expectedPeersLen: %d, peers: %+v\n", expectedPeersLen, peers)
 				if len(peers) != expectedPeersLen {
 					allConnected = false
 					clients = clients[:0]

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -68,7 +68,6 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 		return nil, nil, nil, fmt.Errorf("at least 2 nodes are required")
 	}
 
-	// Synchronize Thor binary build
 	buildMutex.Lock()
 	defer buildMutex.Unlock()
 

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -316,7 +316,7 @@ func cleanupPorts(ports []int) {
 
 // isPortAvailable checks if a port is actually available for binding
 func isPortAvailable(port int) bool {
-	addr := fmt.Sprintf("0.0.0.0:%d", port)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return false

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/vechain/thor/v2/thorclient"
@@ -61,11 +62,7 @@ func Genesis(config *Config) *genesis.CustomGenesis {
 		Build()
 }
 
-func StartNetwork(config *Config) (*thorclient.Client, environments.Actions, func(), error) {
-	return StartNetworkWithID(config, "default")
-}
-
-func StartNetworkWithID(config *Config, networkID string) (*thorclient.Client, environments.Actions, func(), error) {
+func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environments.Actions, func(), error) {
 	if config.Nodes < 2 {
 		return nil, nil, nil, fmt.Errorf("at least 2 nodes are required")
 	}
@@ -105,6 +102,11 @@ func StartNetworkWithID(config *Config, networkID string) (*thorclient.Client, e
 	customGenesis := Genesis(config)
 	nodes := make([]node.Config, config.Nodes)
 	usedPorts := make([]int, 0, config.Nodes*2) // API and P2P ports
+
+	networkID := "default"
+	if t != nil {
+		networkID = fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano())
+	}
 
 	for i := range config.Nodes {
 		additionalArgs := map[string]string{

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -161,7 +161,7 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 		return nil, nil, nil, err
 	}
 
-	if err = networkCfg.HealthCheck(0, 40*time.Second); err != nil {
+	if err = networkCfg.HealthCheck(0, 2*time.Minute); err != nil {
 		hayabusaNetwork.StopNetwork()
 
 		cleanupPorts(usedPorts)

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -169,7 +169,7 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 		return nil, nil, nil, fmt.Errorf("health check failed: %w", err)
 	}
 
-	pollingWhileConnectingPeers(t, nodes, config.Nodes)
+	pollingWhileConnectingPeers(t, nodes, config.Nodes - 1)
 
 	// verbose logging for node 0, use node 1 for http (simulation etc.). Amount validated on first line of function
 	client := thorclient.New(nodes[1].GetHTTPAddr())
@@ -341,7 +341,6 @@ func pollingWhileConnectingPeers(t *testing.T, nodes []node.Config, expectedPeer
 				c := thorclient.New(node.GetHTTPAddr())
 				peers, err := c.Peers()
 				assert.NoError(t, err)
-				fmt.Printf("LLEGA: expectedPeersLen: %d, peers: %+v\n", expectedPeersLen, peers)
 				if len(peers) != expectedPeersLen {
 					allConnected = false
 					clients = clients[:0]

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -104,9 +104,9 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 	nodes := make([]node.Config, config.Nodes)
 	usedPorts := make([]int, 0, config.Nodes*2) // API and P2P ports
 
-	networkID := "default"
+	testID := "default"
 	if t != nil {
-		networkID = fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano())
+		testID = t.Name()
 	}
 
 	for i := range config.Nodes {
@@ -119,7 +119,7 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 			additionalArgs["verbosity-staker"] = strconv.Itoa(stakerVerbosity)
 		}
 
-		nodeID := fmt.Sprintf("%s-Node-%d", networkID, i)
+		nodeID := fmt.Sprintf("%s-Node-%d", testID, i)
 		apiPort := rndPort()
 		p2pPort := rndPort()
 		usedPorts = append(usedPorts, apiPort, p2pPort)
@@ -136,7 +136,7 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 	}
 	networkCfg := &networkhubNetwork.Network{
 		Environment: "local",
-		BaseID:      networkID,
+		BaseID:      testID,
 		Nodes:       nodes,
 		ThorBuilder: thorBuilder,
 	}

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/vechain/thor/v2/thorclient"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -28,6 +27,7 @@ import (
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/thorclient/bind"
 
+	"github.com/vechain/hayabusa-e2e/utils"
 	networkhubNetwork "github.com/vechain/networkhub/network"
 	thorgenesis "github.com/vechain/thor/v2/genesis"
 )
@@ -169,7 +169,7 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 		return nil, nil, nil, fmt.Errorf("health check failed: %w", err)
 	}
 
-	pollingWhileConnectingPeers(t, nodes, config.Nodes - 1)
+	utils.WaitForPeersConnection(t, nodes, config.Nodes-1)
 
 	// verbose logging for node 0, use node 1 for http (simulation etc.). Amount validated on first line of function
 	client := thorclient.New(nodes[1].GetHTTPAddr())
@@ -323,34 +323,4 @@ func isPortAvailable(port int) bool {
 	}
 	ln.Close()
 	return true
-}
-
-func pollingWhileConnectingPeers(t *testing.T, nodes []node.Config, expectedPeersLen int) []*thorclient.Client {
-	// Polling approach with timeout
-	timeout := time.After(1 * time.Minute)
-	tick := time.Tick(5 * time.Second)
-
-	clients := make([]*thorclient.Client, 0)
-	for {
-		select {
-		case <-timeout:
-			t.Fatal("timed out waiting for nodes to connect")
-		case <-tick:
-			allConnected := true
-			for _, node := range nodes {
-				c := thorclient.New(node.GetHTTPAddr())
-				peers, err := c.Peers()
-				assert.NoError(t, err)
-				if len(peers) != expectedPeersLen {
-					allConnected = false
-					clients = clients[:0]
-					break
-				}
-				clients = append(clients, c)
-			}
-			if allConnected {
-				return clients
-			}
-		}
-	}
 }

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -141,14 +141,12 @@ func StartNetworkWithID(config *Config, networkID string) (*thorclient.Client, e
 	networkHub := client.New()
 	networkIDResult, err := networkHub.Config(networkCfg)
 	if err != nil {
-
 		cleanupPorts(usedPorts)
 		return nil, nil, nil, err
 	}
 
 	hayabusaNetwork, err := networkHub.GetNetwork(networkIDResult.ID())
 	if err != nil {
-
 		cleanupPorts(usedPorts)
 		return nil, nil, nil, err
 	}
@@ -161,7 +159,7 @@ func StartNetworkWithID(config *Config, networkID string) (*thorclient.Client, e
 		return nil, nil, nil, err
 	}
 
-	if err = networkCfg.HealthCheck(0, 30*time.Second); err != nil {
+	if err = networkCfg.HealthCheck(0, 40*time.Second); err != nil {
 		hayabusaNetwork.StopNetwork()
 
 		cleanupPorts(usedPorts)
@@ -172,7 +170,6 @@ func StartNetworkWithID(config *Config, networkID string) (*thorclient.Client, e
 	client := thorclient.New(nodes[1].GetHTTPAddr())
 
 	return client, hayabusaNetwork, func() {
-
 		cleanupPorts(usedPorts)
 
 		if err := hayabusaNetwork.StopNetwork(); err != nil {

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -130,7 +130,7 @@ func StartNetwork(t *testing.T, config *Config) (*thorclient.Client, environment
 			Genesis:        customGenesis,
 			Verbosity:      verbosity,
 			AdditionalArgs: additionalArgs,
-			APIAddr:        fmt.Sprintf("127.0.0.1:%d", apiPort),
+			APIAddr:        fmt.Sprintf("0.0.0.0:%d", apiPort),
 			P2PListenPort:  p2pPort,
 		}
 	}
@@ -316,7 +316,7 @@ func cleanupPorts(ports []int) {
 
 // isPortAvailable checks if a port is actually available for binding
 func isPortAvailable(port int) bool {
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return false

--- a/tests/delegations/delegations_test.go
+++ b/tests/delegations/delegations_test.go
@@ -269,7 +269,7 @@ func newDelegationSetup(t *testing.T) (*builtin.Staker, *hayabusa.Config, [6]tho
 		MidStakingPeriod:  12,
 		HighStakingPeriod: 259200,
 	}
-	client, _, cancel, err := hayabusa.StartNetwork(config)
+	client, _, cancel, err := hayabusa.StartNetwork(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/energy/energy_test.go
+++ b/tests/energy/energy_test.go
@@ -1,7 +1,6 @@
 package energy
 
 import (
-	"fmt"
 	"math/big"
 	"strconv"
 	"testing"
@@ -15,6 +14,12 @@ import (
 )
 
 func TestEnergy(t *testing.T) {
+	testutil.RunFlakyTest(t, func() error {
+		return runEnergyTest(t)
+	})
+}
+
+func runEnergyTest(t *testing.T) error {
 	config := &hayabusa.Config{
 		Nodes:             3,
 		MaxBlockProposers: 3,
@@ -104,17 +109,16 @@ func TestEnergy(t *testing.T) {
 	}
 	t.Logf("✅ - PoS growth is as expected")
 
-	fmt.Printf("LLEGA RECEIPTS: %+v\n", receipts)
-
 	actualStakerRewards := new(big.Int)
 	for _, receipt := range receipts {
 		validatorID := receipt.Outputs[0].Events[0].Topics[3]
-		fmt.Printf("LLEGA validatorID: %s\n", validatorID.String())
 		validator, err := staker.Get(validatorID)
 		require.NoError(t, err)
-		fmt.Printf("LLEGA validator: %+v\n", validator)
+
+		if validator.Status == builtin.StakerStatusUnknown {
+			return testutil.StakerStatusUnknownError{ValidationID: validatorID.String()}
+		}
 		rewards, err := staker.GetRewards(validatorID, 1)
-		fmt.Printf("LLEGA rewards: %s\n", rewards.String())
 		require.NoError(t, err)
 		actualStakerRewards = actualStakerRewards.Add(actualStakerRewards, rewards)
 	}
@@ -123,4 +127,6 @@ func TestEnergy(t *testing.T) {
 	expectedStakerRewards := new(big.Int).Mul(hayabusaGrowth, big.NewInt(int64(config.MinStakingPeriod)))
 	require.Equal(t, expectedStakerRewards, actualStakerRewards)
 	t.Logf("✅ - Staker rewards are as expected")
+
+	return nil
 }

--- a/tests/energy/energy_test.go
+++ b/tests/energy/energy_test.go
@@ -110,6 +110,9 @@ func TestEnergy(t *testing.T) {
 	for _, receipt := range receipts {
 		validatorID := receipt.Outputs[0].Events[0].Topics[3]
 		fmt.Printf("LLEGA validatorID: %s\n", validatorID.String())
+		validator, err := staker.Get(validatorID)
+		require.NoError(t, err)
+		fmt.Printf("LLEGA validator: %+v\n", validator)
 		rewards, err := staker.GetRewards(validatorID, 1)
 		fmt.Printf("LLEGA rewards: %s\n", rewards.String())
 		require.NoError(t, err)

--- a/tests/energy/energy_test.go
+++ b/tests/energy/energy_test.go
@@ -37,6 +37,8 @@ func TestEnergy(t *testing.T) {
 	energy, err := builtin.NewEnergy(client)
 	require.NoError(t, err)
 
+	energy.Raw().Client().AccountStorage()
+
 	require.NoError(t, utils.WaitForFork(staker, config.ForkBlock))
 
 	senders := &utils.Senders{}

--- a/tests/energy/energy_test.go
+++ b/tests/energy/energy_test.go
@@ -1,6 +1,7 @@
 package energy
 
 import (
+	"fmt"
 	"math/big"
 	"strconv"
 	"testing"
@@ -103,10 +104,14 @@ func TestEnergy(t *testing.T) {
 	}
 	t.Logf("✅ - PoS growth is as expected")
 
+	fmt.Printf("LLEGA RECEIPTS: %+v\n", receipts)
+
 	actualStakerRewards := new(big.Int)
 	for _, receipt := range receipts {
 		validatorID := receipt.Outputs[0].Events[0].Topics[3]
+		fmt.Printf("LLEGA validatorID: %s\n", validatorID.String())
 		rewards, err := staker.GetRewards(validatorID, 1)
+		fmt.Printf("LLEGA rewards: %s\n", rewards.String())
 		require.NoError(t, err)
 		actualStakerRewards = actualStakerRewards.Add(actualStakerRewards, rewards)
 	}

--- a/tests/energy/energy_test.go
+++ b/tests/energy/energy_test.go
@@ -37,8 +37,6 @@ func TestEnergy(t *testing.T) {
 	energy, err := builtin.NewEnergy(client)
 	require.NoError(t, err)
 
-	energy.Raw().Client().AccountStorage()
-
 	require.NoError(t, utils.WaitForFork(staker, config.ForkBlock))
 
 	senders := &utils.Senders{}

--- a/tests/energy/energy_test.go
+++ b/tests/energy/energy_test.go
@@ -26,7 +26,7 @@ func TestEnergy(t *testing.T) {
 		HighStakingPeriod: 180,
 	}
 	genesis := hayabusa.Genesis(config)
-	client, _, cancel, err := hayabusa.StartNetwork(config)
+	client, _, cancel, err := hayabusa.StartNetwork(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/slots/slots_test.go
+++ b/tests/slots/slots_test.go
@@ -28,7 +28,7 @@ func Test_MissedSlot(t *testing.T) {
 		MidStakingPeriod:  12,
 		HighStakingPeriod: 259200,
 	}
-	client, network, cancel, err := hayabusa.StartNetwork(config)
+	client, network, cancel, err := hayabusa.StartNetwork(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/slots/slots_test.go
+++ b/tests/slots/slots_test.go
@@ -16,6 +16,12 @@ import (
 )
 
 func Test_MissedSlot(t *testing.T) {
+	testutil.RunFlakyTest(t, func() error {
+		return runTestMissedSlot(t)
+	})
+}
+
+func runTestMissedSlot(t *testing.T) error {
 	config := &hayabusa.Config{
 		Nodes:             3,
 		MaxBlockProposers: 3,
@@ -92,16 +98,20 @@ func Test_MissedSlot(t *testing.T) {
 	require.NoError(t, network.Nodes()[validator1.GetID()].Start())
 
 	// wait for the validator to be back online
-	err = ticker.WaitForCondition(time.Minute*10, func() (bool, error) {
+	err = ticker.WaitForCondition(time.Minute*1, func() (bool, error) {
 		validation, err := staker.Get(validationID)
 		require.NoError(t, err)
 		t.Logf("⚠️ - waiting for validator %s to be online, status: %v", validationID.String(), validation.Status)
 		return validation.Online, nil
 	})
-	require.NoError(t, err)
+	if err != nil {
+		return testutil.StakerStatusUnknownError{ValidationID: validationID.String()}
+	}
 
 	validation, err = staker.Get(validationID)
 	require.NoError(t, err)
 	require.True(t, validation.Online)
 	t.Log("✅ - validator back online")
+
+	return nil
 }

--- a/tests/slots/slots_test.go
+++ b/tests/slots/slots_test.go
@@ -95,6 +95,7 @@ func Test_MissedSlot(t *testing.T) {
 	err = ticker.WaitForCondition(time.Minute*10, func() (bool, error) {
 		validation, err := staker.Get(validationID)
 		require.NoError(t, err)
+		t.Logf("⚠️ - waiting for validator %s to be online, status: %v", validationID.String(), validation.Status)
 		return validation.Online, nil
 	})
 	require.NoError(t, err)

--- a/tests/slots/slots_test.go
+++ b/tests/slots/slots_test.go
@@ -65,7 +65,7 @@ func Test_MissedSlot(t *testing.T) {
 	require.NoError(t, ticker.WaitForBlock(block))
 
 	// wait for a missed slot
-	prev, err := ticker.Wait(25 * time.Second)
+	prev, err := ticker.Wait(35 * time.Second)
 	require.NoError(t, err)
 	// shut the validator down
 	require.NoError(t, network.Nodes()[validator1.GetID()].Stop())
@@ -92,7 +92,7 @@ func Test_MissedSlot(t *testing.T) {
 	require.NoError(t, network.Nodes()[validator1.GetID()].Start())
 
 	// wait for the validator to be back online
-	err = ticker.WaitForCondition(time.Second*120, func() (bool, error) {
+	err = ticker.WaitForCondition(time.Second*150, func() (bool, error) {
 		validation, err := staker.Get(validationID)
 		require.NoError(t, err)
 		return validation.Online, nil

--- a/tests/slots/slots_test.go
+++ b/tests/slots/slots_test.go
@@ -1,7 +1,6 @@
 package slots
 
 import (
-	"log/slog"
 	"math/big"
 	"testing"
 	"time"
@@ -92,10 +91,8 @@ func Test_MissedSlot(t *testing.T) {
 	// start the validator again
 	require.NoError(t, network.Nodes()[validator1.GetID()].Start())
 
-	slog.Info("Waiting for validator to be back online", "validator", validator1.GetID(), "validationID", validationID)
-
 	// wait for the validator to be back online
-	err = ticker.WaitForCondition(time.Second*120, func() (bool, error) {
+	err = ticker.WaitForCondition(time.Minute*3, func() (bool, error) {
 		validation, err := staker.Get(validationID)
 		require.NoError(t, err)
 		return validation.Online, nil

--- a/tests/slots/slots_test.go
+++ b/tests/slots/slots_test.go
@@ -1,6 +1,7 @@
 package slots
 
 import (
+	"log/slog"
 	"math/big"
 	"testing"
 	"time"
@@ -91,8 +92,10 @@ func Test_MissedSlot(t *testing.T) {
 	// start the validator again
 	require.NoError(t, network.Nodes()[validator1.GetID()].Start())
 
+	slog.Info("Waiting for validator to be back online", "validator", validator1.GetID(), "validationID", validationID)
+
 	// wait for the validator to be back online
-	err = ticker.WaitForCondition(time.Second*150, func() (bool, error) {
+	err = ticker.WaitForCondition(time.Second*120, func() (bool, error) {
 		validation, err := staker.Get(validationID)
 		require.NoError(t, err)
 		return validation.Online, nil

--- a/tests/slots/slots_test.go
+++ b/tests/slots/slots_test.go
@@ -92,7 +92,7 @@ func Test_MissedSlot(t *testing.T) {
 	require.NoError(t, network.Nodes()[validator1.GetID()].Start())
 
 	// wait for the validator to be back online
-	err = ticker.WaitForCondition(time.Minute*3, func() (bool, error) {
+	err = ticker.WaitForCondition(time.Minute*10, func() (bool, error) {
 		validation, err := staker.Get(validationID)
 		require.NoError(t, err)
 		return validation.Online, nil

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -429,9 +429,27 @@ func newDelegationSetup(t *testing.T) (*builtin.Staker, *stargate.Stargate, *hay
 
 	posBlock := config.ForkBlock + config.TransitionPeriod
 	if err := utils.WaitForPOS(staker, posBlock); err != nil {
-		t.Fatalf("failed to wait for PoS: %v", err)
+		t.Logf("⚠️ WaitForPOS failed: %v, continuing to wait for PoS activation...", err)
+
+		timeout := time.After(10 * time.Minute)
+		tick := time.NewTicker(2 * time.Second)
+		defer tick.Stop()
+
+		for {
+			select {
+			case <-timeout:
+				t.Fatalf("timed out waiting for PoS activation after 10 minutes")
+			case <-tick.C:
+				_, id, err := staker.FirstActive()
+				if err == nil && !id.IsZero() {
+					t.Logf("✅ PoS is now active with delay")
+					goto posActive
+				}
+			}
+		}
 	}
 
+posActive:
 	wg.Wait()
 
 	return staker, stargate, config, validationIDs

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -2,6 +2,7 @@ package stargate
 
 import (
 	"fmt"
+	"log/slog"
 	"math/big"
 	"strconv"
 	"strings"
@@ -38,6 +39,7 @@ func Test_Stargate_SingleDelegator(t *testing.T) {
 	require.NoError(t, ticker.WaitForBlock(block))
 	err = ticker.WaitForCondition(time.Minute*10, func() (bool, error) {
 		completed, err := staker.GetCompletedPeriods(validationID)
+		slog.Info("Completed periods, waiting for 1", "completed", completed)
 		if err != nil {
 			return false, err
 		}

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -379,7 +379,7 @@ func newDelegationSetup(t *testing.T) (*builtin.Staker, *stargate.Stargate, *hay
 		MidStakingPeriod:  12,
 		HighStakingPeriod: 24,
 	}
-	client, _, cancel, err := hayabusa.StartNetwork(config)
+	client, _, cancel, err := hayabusa.StartNetwork(t, config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -36,6 +36,13 @@ func Test_Stargate_SingleDelegator(t *testing.T) {
 	// wait for the validator to complete 1 staking period
 	block := config.ForkBlock + config.TransitionPeriod + config.MinStakingPeriod
 	require.NoError(t, ticker.WaitForBlock(block))
+	ticker.WaitForCondition(time.Minute*5, func() (bool, error) {
+		completed, err := staker.GetCompletedPeriods(validationID)
+		if err != nil {
+			return false, err
+		}
+		return *completed == 1, nil
+	})
 	completed, err := staker.GetCompletedPeriods(validationID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, int(*completed))

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -2,7 +2,6 @@ package stargate
 
 import (
 	"fmt"
-	"log/slog"
 	"math/big"
 	"strconv"
 	"strings"
@@ -418,14 +417,10 @@ func newDelegationSetup(t *testing.T) (*builtin.Staker, *stargate.Stargate, *hay
 		}
 	}
 
-	posBlock := config.ForkBlock + config.TransitionPeriod
+	// In case we have forks dPoS might be activated later than the transition period
+	posBlock := config.ForkBlock + 2*config.TransitionPeriod
 	if err := utils.WaitForPOS(staker, posBlock); err != nil {
-		slog.Info("❌ - failed to wait for PoS, waiting a bit more", "posBlock", posBlock)
-		// In principle fork block + transition period should be enough, but we add min staking period due to some flakiness
-		posBlock += config.MinStakingPeriod
-		if err := utils.WaitForPOS(staker, posBlock); err != nil {
-			t.Fatalf("failed to wait for PoS: %v", err)
-		}
+		t.Fatalf("failed to wait for PoS: %v", err)
 	}
 
 	wg.Wait()

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -417,8 +417,7 @@ func newDelegationSetup(t *testing.T) (*builtin.Staker, *stargate.Stargate, *hay
 		}
 	}
 
-	// In case we have forks dPoS might be activated later than the transition period
-	posBlock := config.ForkBlock + 2*config.TransitionPeriod
+	posBlock := config.ForkBlock + config.TransitionPeriod
 	if err := utils.WaitForPOS(staker, posBlock); err != nil {
 		t.Fatalf("failed to wait for PoS: %v", err)
 	}

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -36,13 +36,14 @@ func Test_Stargate_SingleDelegator(t *testing.T) {
 	// wait for the validator to complete 1 staking period
 	block := config.ForkBlock + config.TransitionPeriod + config.MinStakingPeriod
 	require.NoError(t, ticker.WaitForBlock(block))
-	ticker.WaitForCondition(time.Minute*5, func() (bool, error) {
+	err = ticker.WaitForCondition(time.Minute*5, func() (bool, error) {
 		completed, err := staker.GetCompletedPeriods(validationID)
 		if err != nil {
 			return false, err
 		}
 		return *completed == 1, nil
 	})
+	require.NoError(t, err)
 	completed, err := staker.GetCompletedPeriods(validationID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, int(*completed))

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -438,7 +438,7 @@ func newDelegationSetup(t *testing.T) (*builtin.Staker, *stargate.Stargate, *hay
 		for {
 			select {
 			case <-timeout:
-				t.Fatalf("timed out waiting for PoS activation after 10 minutes")
+				t.Fatalf("timed out waiting for PoS activation")
 			case <-tick.C:
 				_, id, err := staker.FirstActive()
 				if err == nil && !id.IsZero() {

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -36,7 +36,7 @@ func Test_Stargate_SingleDelegator(t *testing.T) {
 	// wait for the validator to complete 1 staking period
 	block := config.ForkBlock + config.TransitionPeriod + config.MinStakingPeriod
 	require.NoError(t, ticker.WaitForBlock(block))
-	err = ticker.WaitForCondition(time.Minute*5, func() (bool, error) {
+	err = ticker.WaitForCondition(time.Minute*10, func() (bool, error) {
 		completed, err := staker.GetCompletedPeriods(validationID)
 		if err != nil {
 			return false, err

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -54,7 +54,6 @@ func runTestStargateSingleDelegator(t *testing.T) error {
 	if err != nil {
 		return testutil.StakerStatusUnknownError{ValidationID: validationID.String()}
 	}
-	require.NoError(t, err)
 	completed, err := staker.GetCompletedPeriods(validationID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, int(*completed))

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -27,6 +27,12 @@ import (
 )
 
 func Test_Stargate_SingleDelegator(t *testing.T) {
+	testutil.RunFlakyTest(t, func() error {
+		return runTestStargateSingleDelegator(t)
+	})
+}
+
+func runTestStargateSingleDelegator(t *testing.T) error {
 	staker, stargate, config, validationIDs := newDelegationSetup(t)
 
 	validationID := validationIDs[0]
@@ -37,7 +43,7 @@ func Test_Stargate_SingleDelegator(t *testing.T) {
 	// wait for the validator to complete 1 staking period
 	block := config.ForkBlock + config.TransitionPeriod + config.MinStakingPeriod
 	require.NoError(t, ticker.WaitForBlock(block))
-	err = ticker.WaitForCondition(time.Minute*10, func() (bool, error) {
+	err = ticker.WaitForCondition(time.Minute*1, func() (bool, error) {
 		completed, err := staker.GetCompletedPeriods(validationID)
 		slog.Info("⚠️ - completed periods, waiting for greater than 0", "completed", int(*completed))
 		if err != nil {
@@ -45,6 +51,9 @@ func Test_Stargate_SingleDelegator(t *testing.T) {
 		}
 		return *completed > 0, nil
 	})
+	if err != nil {
+		return testutil.StakerStatusUnknownError{ValidationID: validationID.String()}
+	}
 	require.NoError(t, err)
 	completed, err := staker.GetCompletedPeriods(validationID)
 	require.NoError(t, err)
@@ -163,6 +172,8 @@ func Test_Stargate_SingleDelegator(t *testing.T) {
 
 	t.Logf("✅ total rewards for: %s", totalPeriodRewards.String())
 	assert.Equal(t, new(big.Int).Add(proposerReward, delegatorReward), totalPeriodRewards)
+
+	return nil
 }
 
 func Test_Stargate_DelegatorFlow_Stake_And_Claim_Auto_Renew_Off(t *testing.T) {

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -2,6 +2,7 @@ package stargate
 
 import (
 	"fmt"
+	"log/slog"
 	"math/big"
 	"strconv"
 	"strings"
@@ -416,8 +417,15 @@ func newDelegationSetup(t *testing.T) (*builtin.Staker, *stargate.Stargate, *hay
 			validationIDs[i] = receiptToID(receipts[i])
 		}
 	}
-	if err := utils.WaitForPOS(staker, config.ForkBlock+config.TransitionPeriod); err != nil {
-		t.Fatalf("failed to wait for PoS: %v", err)
+
+	posBlock := config.ForkBlock + config.TransitionPeriod
+	if err := utils.WaitForPOS(staker, posBlock); err != nil {
+		slog.Info("❌ - failed to wait for PoS, waiting a bit more", "posBlock", posBlock)
+		// In principle fork block + transition period should be enough, but we add min staking period due to some flakiness
+		posBlock += config.MinStakingPeriod
+		if err := utils.WaitForPOS(staker, posBlock); err != nil {
+			t.Fatalf("failed to wait for PoS: %v", err)
+		}
 	}
 
 	wg.Wait()

--- a/tests/stargate/stargate_test.go
+++ b/tests/stargate/stargate_test.go
@@ -39,11 +39,11 @@ func Test_Stargate_SingleDelegator(t *testing.T) {
 	require.NoError(t, ticker.WaitForBlock(block))
 	err = ticker.WaitForCondition(time.Minute*10, func() (bool, error) {
 		completed, err := staker.GetCompletedPeriods(validationID)
-		slog.Info("Completed periods, waiting for 1", "completed", completed)
+		slog.Info("⚠️ - completed periods, waiting for greater than 0", "completed", int(*completed))
 		if err != nil {
 			return false, err
 		}
-		return *completed == 1, nil
+		return *completed > 0, nil
 	})
 	require.NoError(t, err)
 	completed, err := staker.GetCompletedPeriods(validationID)

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -725,7 +725,7 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedStatus, validator.Status, "validatorID", validatorID.String())
+	assert.Equal(t, expectedStatus, validator.Status)
 }
 
 func assertValidatorStakingPeriod(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes32, expectedPeriod uint32) {

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -671,7 +671,7 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
 	if validator.Status == builtin.StakerStatusUnknown {
-		slog.Info("❌ - validator status unknown", 
+		slog.Info("❌ - validator status unknown, retrying for up to 2 minutes",
 			"validatorID", validatorID.String(),
 			"status", validator.Status,
 			"master", validator.Master,
@@ -681,6 +681,23 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 			"online", validator.Online,
 			"BLOCK", waitForBlock,
 		)
+
+		ticker := utils.NewTicker(staker.Raw().Client())
+		err := ticker.WaitForCondition(2*time.Minute, func() (bool, error) {
+			validator, err := staker.Get(validatorID)
+			if err != nil {
+				return false, err
+			}
+			if validator.Status != builtin.StakerStatusUnknown {
+				slog.Info("✅ - validator status changed from unknown",
+					"validatorID", validatorID.String(),
+					"newStatus", validator.Status,
+				)
+				return true, nil
+			}
+			return false, nil
+		})
+		assert.NoError(t, err, "Validator %s status remained unknown after 2 minutes", validatorID.String())
 	}
 	assert.Equal(t, expectedStatus, validator.Status)
 }

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -731,11 +731,7 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 		err = utils.NewTicker(staker.Raw().Client()).WaitForCondition(time.Minute*10, func() (bool, error) {
 			unknownValidator, err := staker.Get(validatorID)
 			assert.NoError(t, err)
-			slog.Info("⚠️ - validator status set after unknown (1)", "validator", validatorID.String(), "status", unknownValidator.Status)
-			staker2, _ := builtin.NewStaker(staker.Raw().Client())
-			unknownValidator2, err := staker2.Get(validatorID)
-			assert.NoError(t, err)
-			slog.Info("⚠️ - validator status set after unknown (2)", "validator", validatorID.String(), "status", unknownValidator2.Status)
+			slog.Info("⚠️ - validator status set after unknown", "validator", validatorID.String(), "status", unknownValidator.Status)
 			return unknownValidator.Status != builtin.StakerStatusUnknown, nil
 		})
 		assert.NoError(t, err)

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vechain/hayabusa-e2e/hayabusa"
 	"github.com/vechain/hayabusa-e2e/testutil"
 	"github.com/vechain/hayabusa-e2e/utils"
+	"github.com/vechain/networkhub/environments"
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/thorclient"
 	"github.com/vechain/thor/v2/thorclient/bind"
@@ -20,7 +21,7 @@ import (
 
 func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 3)
+	config, hayabusaNetwork, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1NonPoA := hayabusa.AdditionalAccounts[0]
@@ -51,8 +52,8 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Log("✅ - Queued validator OK", "id", id2.String())
 
 	block := config.ForkBlock + config.TransitionPeriod
-	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
-	assertValidatorStatus(t, staker, id2, builtin.StakerStatusActive, block)
+	assertValidatorStatusHayabusa(t, hayabusaNetwork, staker, id1, builtin.StakerStatusActive, block)
+	assertValidatorStatusHayabusa(t, hayabusaNetwork, staker, id2, builtin.StakerStatusActive, block)
 
 	id3 := addValidator(t, staker, validator1NonPoA, false, config.MinStakingPeriod)
 	assertValidatorStatus(t, staker, id3, builtin.StakerStatusQueued, block)
@@ -63,7 +64,7 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 
 func TestHayabusaNoForkThenJoinLater(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 3)
+	config, _, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -112,7 +113,7 @@ func TestHayabusaNoForkThenJoinLater(t *testing.T) {
 
 func TestHayabusaFullFlowJoinQueuedCooldownExit(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 3)
+	config, _, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -204,7 +205,7 @@ func TestHayabusaFullFlowJoinQueuedCooldownExit(t *testing.T) {
 
 func TestHayabusaQueuedAndThenEnter(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 3)
+	config, _,client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -323,7 +324,7 @@ func TestHayabusaQueuedAndThenEnter(t *testing.T) {
 
 func TestHayabusaValidatorStakeChanges(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 3)
+	config, _, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -462,7 +463,7 @@ func TestHayabusaValidatorStakeChanges(t *testing.T) {
 
 func TestHayabusaQueuedWeightDecreasedWhenValidatorExits(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 2)
+	config, _, client, cancel := setupTestNetwork(t, 2)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -514,7 +515,7 @@ func TestHayabusaQueuedWeightDecreasedWhenValidatorExits(t *testing.T) {
 
 func TestHayabusaQueuedWeightDecreasedWhenValidatorSelectedForLeaderGroup(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 3)
+	config, _, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -581,7 +582,7 @@ func TestHayabusaQueuedWeightDecreasedWhenValidatorSelectedForLeaderGroup(t *tes
 
 func TestHayabusaQueuedStakeAndWeightChangesWhenDelegator(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 1)
+	config, _, client, cancel := setupTestNetwork(t, 1)
 	t.Cleanup(cancel)
 
 	staker := setupStakerAndWaitForFork(t, client, config)
@@ -654,7 +655,7 @@ func TestHayabusaQueuedStakeAndWeightChangesWhenDelegator(t *testing.T) {
 
 func TestHayabusaTotalStakeDecreased(t *testing.T) {
 	t.Parallel()
-	config, client, cancel := setupTestNetwork(t, 3)
+	config, _, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -745,6 +746,40 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.Equal(t, expectedStatus, validator.Status)
 }
 
+func assertValidatorStatusHayabusa(t *testing.T,hayabusaNetwork environments.Actions, staker *builtin.Staker, validatorID thor.Bytes32, expectedStatus builtin.StakerStatus, waitForBlock uint32) {
+	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
+	validator, err := staker.Get(validatorID)
+	assert.NoError(t, err)
+	if validator.Status == builtin.StakerStatusUnknown {
+		slog.Info("⚠️ - validator status is unknown, waiting for it to be set", "validator", validatorID.String())
+		err = utils.NewTicker(staker.Raw().Client()).WaitForCondition(time.Minute*10, func() (bool, error) {
+			unknownValidator, err := staker.Get(validatorID)
+			assert.NoError(t, err)
+			slog.Info("⚠️ - validator status set after unknown (1)", "validator", validatorID.String(), "status", unknownValidator.Status)
+			thorClient0 := thorclient.New(hayabusaNetwork.Config().Nodes[0].GetHTTPAddr())
+			staker2, _ := builtin.NewStaker(thorClient0)
+			unknownValidator2, err := staker2.Get(validatorID)
+			assert.NoError(t, err)
+			slog.Info("⚠️ - validator status set after unknown (2)", "validator", validatorID.String(), "status", unknownValidator2.Status)
+			thorClient2 := thorclient.New(hayabusaNetwork.Config().Nodes[2].GetHTTPAddr())
+			staker3, _ := builtin.NewStaker(thorClient2)
+			unknownValidator3, err := staker3.Get(validatorID)
+			assert.NoError(t, err)
+			slog.Info("⚠️ - validator status set after unknown (3)", "validator", validatorID.String(), "status", unknownValidator3.Status)
+			thorClient1 := thorclient.New(hayabusaNetwork.Config().Nodes[1].GetHTTPAddr())
+			staker4, _ := builtin.NewStaker(thorClient1)
+			unknownValidator4, err := staker4.Get(validatorID)
+			assert.NoError(t, err)
+			slog.Info("⚠️ - validator status set after unknown (4)", "validator", validatorID.String(), "status", unknownValidator4.Status)
+			return unknownValidator.Status != builtin.StakerStatusUnknown, nil
+		})
+		assert.NoError(t, err)
+		validator, err = staker.Get(validatorID)
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, expectedStatus, validator.Status)
+}
+
 func assertValidatorStakingPeriod(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes32, expectedPeriod uint32) {
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
@@ -772,7 +807,7 @@ func assertRewards(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes3
 	assert.Equal(t, big.NewInt(0).Mul(expectedReward, big.NewInt(int64(proposedBlocks))).String(), res.String())
 }
 
-func setupTestNetwork(t *testing.T, maxBlockProposers uint32) (*hayabusa.Config, *thorclient.Client, func()) {
+func setupTestNetwork(t *testing.T, maxBlockProposers uint32) (*hayabusa.Config, environments.Actions, *thorclient.Client, func()) {
 	config := &hayabusa.Config{
 		Nodes:             6,
 		MaxBlockProposers: maxBlockProposers,
@@ -785,12 +820,12 @@ func setupTestNetwork(t *testing.T, maxBlockProposers uint32) (*hayabusa.Config,
 		HighStakingPeriod: 259200,
 	}
 
-	client, _, cancel, err := hayabusa.StartNetwork(t, config)
+	client, hayabusaNetwork, cancel, err := hayabusa.StartNetwork(t, config)
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	return config, client, cancel
+	return config, hayabusaNetwork, client, cancel
 }
 
 func setupStakerAndWaitForFork(t *testing.T, client *thorclient.Client, config *hayabusa.Config) *builtin.Staker {

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -672,9 +672,14 @@ func validatorWithdraw(t *testing.T, staker *builtin.Staker, signer bind.Signer,
 }
 
 func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes32, expectedStatus builtin.StakerStatus, waitForBlock uint32) {
-	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
+	ticker := utils.NewTicker(staker.Raw().Client())
+	assert.NoError(t, ticker.WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
+	if validator.Status == builtin.StakerStatusUnknown {
+		slog.Info("❌ - validator status unknown, waiting for next block", "validator", validatorID.String())
+		assert.NoError(t, ticker.WaitForBlock(waitForBlock + 1))
+	}
 	assert.Equal(t, expectedStatus, validator.Status)
 }
 

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -43,12 +43,12 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	firstQueued, _, err := staker.FirstQueued()
 	assert.NoError(t, err)
 	assert.Equal(t, *firstQueued.Endorsor, validator1PoA.Address())
-	t.Log("✅ - Queued validator OK")
+	t.Log("✅ - Queued validator OK", "id", id1.String())
 
 	id2 := addValidator(t, staker, validator2PoA, true, config.MinStakingPeriod)
 	assertValidatorStatus(t, staker, id2, builtin.StakerStatusQueued, config.ForkBlock)
 
-	t.Log("✅ - Queued validator OK")
+	t.Log("✅ - Queued validator OK", "id", id2.String())
 
 	block := config.ForkBlock + config.TransitionPeriod
 	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
@@ -731,8 +731,12 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 		err = utils.NewTicker(staker.Raw().Client()).WaitForCondition(time.Minute*10, func() (bool, error) {
 			unknownValidator, err := staker.Get(validatorID)
 			assert.NoError(t, err)
-			slog.Info("⚠️ - validator status set after unknown", "validator", validatorID.String(), "status", unknownValidator.Status)
-			return unknownValidator.Status == expectedStatus, nil
+			slog.Info("⚠️ - validator status set after unknown (1)", "validator", validatorID.String(), "status", unknownValidator.Status)
+			staker2, _ := builtin.NewStaker(staker.Raw().Client())
+			unknownValidator2, err := staker2.Get(validatorID)
+			assert.NoError(t, err)
+			slog.Info("⚠️ - validator status set after unknown (2)", "validator", validatorID.String(), "status", unknownValidator2.Status)
+			return unknownValidator.Status != builtin.StakerStatusUnknown, nil
 		})
 		assert.NoError(t, err)
 		validator, err = staker.Get(validatorID)

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -704,10 +704,7 @@ func addValidatorWithStake(t *testing.T, staker *builtin.Staker, signer bind.Sig
 }
 
 func addValidator(t *testing.T, staker *builtin.Staker, signer bind.Signer, autoRenew bool, period uint32) thor.Bytes32 {
-	stake := big.NewInt(1e18)
-	stake = big.NewInt(0).Mul(stake, big.NewInt(1e6))
-	stake = big.NewInt(0).Mul(stake, big.NewInt(25))
-	return addValidatorWithStake(t, staker, signer, autoRenew, stake, period)
+	return addValidatorWithStake(t, staker, signer, autoRenew, calculateValidatorStake(), period)
 }
 
 func validatorWithdraw(t *testing.T, staker *builtin.Staker, signer bind.Signer, validatorID thor.Bytes32) {

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -1,12 +1,10 @@
 package validations
 
 import (
-	"fmt"
 	"log/slog"
 	"math/big"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -711,8 +709,7 @@ func setupTestNetwork(t *testing.T, maxBlockProposers uint32) (*hayabusa.Config,
 		HighStakingPeriod: 259200,
 	}
 
-	testID := fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano())
-	client, _, cancel, err := hayabusa.StartNetworkWithID(config, testID)
+	client, _, cancel, err := hayabusa.StartNetwork(t, config)
 
 	if err != nil {
 		t.Fatal(err)

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -52,8 +52,6 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Log("✅ - Queued validator OK")
 
 	block := config.ForkBlock + config.TransitionPeriod
-	assert.NoError(t, utils.NewTicker(client).WaitForBlock(block))
-
 	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
 	assertValidatorStatus(t, staker, id2, builtin.StakerStatusActive, block)
 

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +24,7 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 
 	validator1NonPoA := hayabusa.AdditionalAccounts[0]
 	validator1PoA := hayabusa.ValidatorAccounts[0]
-	validator2PoA := hayabusa.ValidatorAccounts[10]
+	validator2PoA := hayabusa.ValidatorAccounts[1]
 
 	staker := setupStakerAndWaitForFork(t, client, config)
 
@@ -52,7 +51,7 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 
 	block := config.ForkBlock + config.TransitionPeriod
 	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
-	assertValidatorStatus(t, staker, id2, builtin.StakerStatusActive, block)
+	assertValidatorStatusWithSigner(t, staker, validator2PoA, id2, builtin.StakerStatusActive, block)
 
 	id3 := addValidator(t, staker, validator1NonPoA, false, config.MinStakingPeriod)
 	assertValidatorStatus(t, staker, id3, builtin.StakerStatusQueued, block)
@@ -723,17 +722,20 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
+	assert.Equal(t, expectedStatus, validator.Status)
+}
+
+func assertValidatorStatusWithSigner(t *testing.T, staker *builtin.Staker, signer bind.Signer, validatorID thor.Bytes32, expectedStatus builtin.StakerStatus, waitForBlock uint32) {
+	ticker := utils.NewTicker(staker.Raw().Client())
+	assert.NoError(t, ticker.WaitForBlock(waitForBlock))
+	validator, err := staker.Get(validatorID)
+	assert.NoError(t, err)
 	if validator.Status == builtin.StakerStatusUnknown {
-		slog.Info("⚠️ - validator status is unknown, waiting for it to be set", "validator", validatorID.String())
-		err = utils.NewTicker(staker.Raw().Client()).WaitForCondition(time.Minute*10, func() (bool, error) {
-			unknownValidator, err := staker.Get(validatorID)
-			assert.NoError(t, err)
-			slog.Info("⚠️ - validator status set after unknown", "validator", validatorID.String(), "status", unknownValidator.Status)
-			return unknownValidator.Status != builtin.StakerStatusUnknown, nil
-		})
-		assert.NoError(t, err)
+		slog.Info("⚠️ - validator status is unknown, adding it again", "validator", validatorID.String())
+		validatorID = addValidator(t, staker, signer, true, waitForBlock)
 		validator, err = staker.Get(validatorID)
 		assert.NoError(t, err)
+		assert.NoError(t, ticker.WaitForBlock(2*waitForBlock))
 	}
 	assert.Equal(t, expectedStatus, validator.Status)
 }

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -25,7 +25,7 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 
 	validator1NonPoA := hayabusa.AdditionalAccounts[0]
 	validator1PoA := hayabusa.ValidatorAccounts[0]
-	validator2PoA := hayabusa.ValidatorAccounts[1]
+	validator2PoA := hayabusa.ValidatorAccounts[10]
 
 	staker := setupStakerAndWaitForFork(t, client, config)
 

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -52,7 +52,6 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Log("✅ - Queued validator OK")
 
 	block := config.ForkBlock + config.TransitionPeriod
-	block += config.TransitionPeriod
 	assert.NoError(t, utils.NewTicker(client).WaitForBlock(block))
 
 	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -671,6 +671,18 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
+	if validator.Status == builtin.StakerStatusUnknown {
+		slog.Info("❌ - validator status unknown", 
+			"validatorID", validatorID.String(),
+			"status", validator.Status,
+			"master", validator.Master,
+			"endorsor", validator.Endorsor,
+			"stake", validator.Stake,
+			"autoRenew", validator.AutoRenew,
+			"online", validator.Online,
+			"BLOCK", waitForBlock,
+		)
+	}
 	assert.Equal(t, expectedStatus, validator.Status)
 }
 

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -677,8 +677,17 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
 	if validator.Status == builtin.StakerStatusUnknown {
-		slog.Info("❌ - validator status unknown, waiting for next block", "validator", validatorID.String())
-		assert.NoError(t, ticker.WaitForBlock(waitForBlock + 1))
+		slog.Info("❌ - validator status unknown, waiting for status change", "validator", validatorID.String())
+		err := ticker.WaitForCondition(30*time.Second, func() (bool, error) {
+			validator, err := staker.Get(validatorID)
+			if err != nil {
+				return false, err
+			}
+			return validator.Status != builtin.StakerStatusUnknown, nil
+		})
+		assert.NoError(t, err, "Validator %s status remained unknown", validatorID.String())
+		validator, err = staker.Get(validatorID)
+		assert.NoError(t, err)
 	}
 	assert.Equal(t, expectedStatus, validator.Status)
 }

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,7 +52,6 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 
 	block := config.ForkBlock + config.TransitionPeriod
 	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
-	block += config.MinStakingPeriod
 	assertValidatorStatus(t, staker, id2, builtin.StakerStatusActive, block)
 
 	id3 := addValidator(t, staker, validator1NonPoA, false, config.MinStakingPeriod)
@@ -726,6 +726,17 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
+	if validator.Status == builtin.StakerStatusUnknown {
+		slog.Info("⚠️ - validator status is unknown, waiting for it to be set", "validator", validatorID.String())
+		err = utils.NewTicker(staker.Raw().Client()).WaitForCondition(time.Minute*10, func() (bool, error) {
+			unknownValidator, err := staker.Get(validatorID)
+			assert.NoError(t, err)
+			return unknownValidator.Status != builtin.StakerStatusUnknown, nil
+		})
+		assert.NoError(t, err)
+		validator, err = staker.Get(validatorID)
+		assert.NoError(t, err)
+	}
 	assert.Equal(t, expectedStatus, validator.Status)
 }
 

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -51,13 +51,9 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 
 	t.Log("✅ - Queued validator OK")
 
-	currentBlock, err := client.Block("best")
-	assert.NoError(t, err)
-
-	ticker := utils.NewTicker(client)
-	block := currentBlock.Number
+	block := config.ForkBlock + config.TransitionPeriod
 	block += config.TransitionPeriod
-	assert.NoError(t, ticker.WaitForBlock(block))
+	assert.NoError(t, utils.NewTicker(client).WaitForBlock(block))
 
 	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
 	assertValidatorStatus(t, staker, id2, builtin.StakerStatusActive, block)
@@ -676,19 +672,6 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.NoError(t, ticker.WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
-	if validator.Status == builtin.StakerStatusUnknown {
-		slog.Info("❌ - validator status unknown, waiting for status change", "validator", validatorID.String())
-		err := ticker.WaitForCondition(30*time.Second, func() (bool, error) {
-			validator, err := staker.Get(validatorID)
-			if err != nil {
-				return false, err
-			}
-			return validator.Status != builtin.StakerStatusUnknown, nil
-		})
-		assert.NoError(t, err, "Validator %s status remained unknown", validatorID.String())
-		validator, err = staker.Get(validatorID)
-		assert.NoError(t, err)
-	}
 	assert.Equal(t, expectedStatus, validator.Status)
 }
 

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -731,7 +731,8 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 		err = utils.NewTicker(staker.Raw().Client()).WaitForCondition(time.Minute*10, func() (bool, error) {
 			unknownValidator, err := staker.Get(validatorID)
 			assert.NoError(t, err)
-			return unknownValidator.Status != builtin.StakerStatusUnknown, nil
+			slog.Info("⚠️ - validator status set after unknown", "validator", validatorID.String(), "status", unknownValidator.Status)
+			return unknownValidator.Status == expectedStatus, nil
 		})
 		assert.NoError(t, err)
 		validator, err = staker.Get(validatorID)

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vechain/hayabusa-e2e/hayabusa"
 	"github.com/vechain/hayabusa-e2e/testutil"
 	"github.com/vechain/hayabusa-e2e/utils"
-	"github.com/vechain/networkhub/environments"
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/thorclient"
 	"github.com/vechain/thor/v2/thorclient/bind"
@@ -21,7 +20,7 @@ import (
 
 func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Parallel()
-	config, hayabusaNetwork, client, cancel := setupTestNetwork(t, 3)
+	config, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1NonPoA := hayabusa.AdditionalAccounts[0]
@@ -52,8 +51,8 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Log("✅ - Queued validator OK", "id", id2.String())
 
 	block := config.ForkBlock + config.TransitionPeriod
-	assertValidatorStatusHayabusa(t, hayabusaNetwork, staker, id1, builtin.StakerStatusActive, block)
-	assertValidatorStatusHayabusa(t, hayabusaNetwork, staker, id2, builtin.StakerStatusActive, block)
+	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
+	assertValidatorStatus(t, staker, id2, builtin.StakerStatusActive, block)
 
 	id3 := addValidator(t, staker, validator1NonPoA, false, config.MinStakingPeriod)
 	assertValidatorStatus(t, staker, id3, builtin.StakerStatusQueued, block)
@@ -64,7 +63,7 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 
 func TestHayabusaNoForkThenJoinLater(t *testing.T) {
 	t.Parallel()
-	config, _, client, cancel := setupTestNetwork(t, 3)
+	config, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -113,7 +112,7 @@ func TestHayabusaNoForkThenJoinLater(t *testing.T) {
 
 func TestHayabusaFullFlowJoinQueuedCooldownExit(t *testing.T) {
 	t.Parallel()
-	config, _, client, cancel := setupTestNetwork(t, 3)
+	config, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -205,7 +204,7 @@ func TestHayabusaFullFlowJoinQueuedCooldownExit(t *testing.T) {
 
 func TestHayabusaQueuedAndThenEnter(t *testing.T) {
 	t.Parallel()
-	config, _,client, cancel := setupTestNetwork(t, 3)
+	config, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -324,7 +323,7 @@ func TestHayabusaQueuedAndThenEnter(t *testing.T) {
 
 func TestHayabusaValidatorStakeChanges(t *testing.T) {
 	t.Parallel()
-	config, _, client, cancel := setupTestNetwork(t, 3)
+	config, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -463,7 +462,7 @@ func TestHayabusaValidatorStakeChanges(t *testing.T) {
 
 func TestHayabusaQueuedWeightDecreasedWhenValidatorExits(t *testing.T) {
 	t.Parallel()
-	config, _, client, cancel := setupTestNetwork(t, 2)
+	config, client, cancel := setupTestNetwork(t, 2)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -515,7 +514,7 @@ func TestHayabusaQueuedWeightDecreasedWhenValidatorExits(t *testing.T) {
 
 func TestHayabusaQueuedWeightDecreasedWhenValidatorSelectedForLeaderGroup(t *testing.T) {
 	t.Parallel()
-	config, _, client, cancel := setupTestNetwork(t, 3)
+	config, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -582,7 +581,7 @@ func TestHayabusaQueuedWeightDecreasedWhenValidatorSelectedForLeaderGroup(t *tes
 
 func TestHayabusaQueuedStakeAndWeightChangesWhenDelegator(t *testing.T) {
 	t.Parallel()
-	config, _, client, cancel := setupTestNetwork(t, 1)
+	config, client, cancel := setupTestNetwork(t, 1)
 	t.Cleanup(cancel)
 
 	staker := setupStakerAndWaitForFork(t, client, config)
@@ -655,7 +654,7 @@ func TestHayabusaQueuedStakeAndWeightChangesWhenDelegator(t *testing.T) {
 
 func TestHayabusaTotalStakeDecreased(t *testing.T) {
 	t.Parallel()
-	config, _, client, cancel := setupTestNetwork(t, 3)
+	config, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
 	validator1 := hayabusa.ValidatorAccounts[0]
@@ -746,40 +745,6 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.Equal(t, expectedStatus, validator.Status)
 }
 
-func assertValidatorStatusHayabusa(t *testing.T,hayabusaNetwork environments.Actions, staker *builtin.Staker, validatorID thor.Bytes32, expectedStatus builtin.StakerStatus, waitForBlock uint32) {
-	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
-	validator, err := staker.Get(validatorID)
-	assert.NoError(t, err)
-	if validator.Status == builtin.StakerStatusUnknown {
-		slog.Info("⚠️ - validator status is unknown, waiting for it to be set", "validator", validatorID.String())
-		err = utils.NewTicker(staker.Raw().Client()).WaitForCondition(time.Minute*10, func() (bool, error) {
-			unknownValidator, err := staker.Get(validatorID)
-			assert.NoError(t, err)
-			slog.Info("⚠️ - validator status set after unknown (1)", "validator", validatorID.String(), "status", unknownValidator.Status)
-			thorClient0 := thorclient.New(hayabusaNetwork.Config().Nodes[0].GetHTTPAddr())
-			staker2, _ := builtin.NewStaker(thorClient0)
-			unknownValidator2, err := staker2.Get(validatorID)
-			assert.NoError(t, err)
-			slog.Info("⚠️ - validator status set after unknown (2)", "validator", validatorID.String(), "status", unknownValidator2.Status)
-			thorClient2 := thorclient.New(hayabusaNetwork.Config().Nodes[2].GetHTTPAddr())
-			staker3, _ := builtin.NewStaker(thorClient2)
-			unknownValidator3, err := staker3.Get(validatorID)
-			assert.NoError(t, err)
-			slog.Info("⚠️ - validator status set after unknown (3)", "validator", validatorID.String(), "status", unknownValidator3.Status)
-			thorClient1 := thorclient.New(hayabusaNetwork.Config().Nodes[1].GetHTTPAddr())
-			staker4, _ := builtin.NewStaker(thorClient1)
-			unknownValidator4, err := staker4.Get(validatorID)
-			assert.NoError(t, err)
-			slog.Info("⚠️ - validator status set after unknown (4)", "validator", validatorID.String(), "status", unknownValidator4.Status)
-			return unknownValidator.Status != builtin.StakerStatusUnknown, nil
-		})
-		assert.NoError(t, err)
-		validator, err = staker.Get(validatorID)
-		assert.NoError(t, err)
-	}
-	assert.Equal(t, expectedStatus, validator.Status)
-}
-
 func assertValidatorStakingPeriod(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes32, expectedPeriod uint32) {
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
@@ -807,7 +772,7 @@ func assertRewards(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes3
 	assert.Equal(t, big.NewInt(0).Mul(expectedReward, big.NewInt(int64(proposedBlocks))).String(), res.String())
 }
 
-func setupTestNetwork(t *testing.T, maxBlockProposers uint32) (*hayabusa.Config, environments.Actions, *thorclient.Client, func()) {
+func setupTestNetwork(t *testing.T, maxBlockProposers uint32) (*hayabusa.Config, *thorclient.Client, func()) {
 	config := &hayabusa.Config{
 		Nodes:             6,
 		MaxBlockProposers: maxBlockProposers,
@@ -820,12 +785,12 @@ func setupTestNetwork(t *testing.T, maxBlockProposers uint32) (*hayabusa.Config,
 		HighStakingPeriod: 259200,
 	}
 
-	client, hayabusaNetwork, cancel, err := hayabusa.StartNetwork(t, config)
+	client, _, cancel, err := hayabusa.StartNetwork(t, config)
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	return config, hayabusaNetwork, client, cancel
+	return config, client, cancel
 }
 
 func setupStakerAndWaitForFork(t *testing.T, client *thorclient.Client, config *hayabusa.Config) *builtin.Staker {

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -19,6 +19,12 @@ import (
 
 func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Parallel()
+	testutil.RunFlakyTest(t, func() error {
+		return runTestHayabusaAddNonPoAValidator(t)
+	})
+}
+
+func runTestHayabusaAddNonPoAValidator(t *testing.T) error {
 	config, client, cancel := setupTestNetwork(t, 3)
 	t.Cleanup(cancel)
 
@@ -45,19 +51,26 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Log("✅ - Queued validator OK", "id", id1.String())
 
 	id2 := addValidator(t, staker, validator2PoA, true, config.MinStakingPeriod)
+
 	assertValidatorStatus(t, staker, id2, builtin.StakerStatusQueued, config.ForkBlock)
 
 	t.Log("✅ - Queued validator OK", "id", id2.String())
 
 	block := config.ForkBlock + config.TransitionPeriod
-	assertValidatorStatusWithSigner(t, staker, validator1PoA, id1, builtin.StakerStatusActive, block)
-	assertValidatorStatusWithSigner(t, staker, validator2PoA, id2, builtin.StakerStatusActive, block)
+	if err := assertValidatorStatusUnknown(t, staker, id1, builtin.StakerStatusActive, block); err != nil {
+		return err
+	}
+	if err := assertValidatorStatusUnknown(t, staker, id2, builtin.StakerStatusActive, block); err != nil {
+		return err
+	}
 
 	id3 := addValidator(t, staker, validator1NonPoA, false, config.MinStakingPeriod)
 	assertValidatorStatus(t, staker, id3, builtin.StakerStatusQueued, block)
 	t.Log("✅ - Not a PoA candidate joined")
 
 	t.Log("✅ - All 3 validators joined")
+
+	return nil
 }
 
 func TestHayabusaNoForkThenJoinLater(t *testing.T) {
@@ -725,19 +738,15 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.Equal(t, expectedStatus, validator.Status)
 }
 
-func assertValidatorStatusWithSigner(t *testing.T, staker *builtin.Staker, signer bind.Signer, validatorID thor.Bytes32, expectedStatus builtin.StakerStatus, waitForBlock uint32) {
-	ticker := utils.NewTicker(staker.Raw().Client())
-	assert.NoError(t, ticker.WaitForBlock(waitForBlock))
+func assertValidatorStatusUnknown(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes32, expectedStatus builtin.StakerStatus, waitForBlock uint32) error {
+	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
 	if validator.Status == builtin.StakerStatusUnknown {
-		slog.Info("⚠️ - validator status is unknown, adding it again", "validator", validatorID.String())
-		validatorID = addValidator(t, staker, signer, true, waitForBlock)
-		validator, err = staker.Get(validatorID)
-		assert.NoError(t, err)
-		assert.NoError(t, ticker.WaitForBlock(2*waitForBlock))
+		return testutil.StakerStatusUnknownError{ValidationID: validatorID.String()}
 	}
 	assert.Equal(t, expectedStatus, validator.Status)
+	return nil
 }
 
 func assertValidatorStakingPeriod(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes32, expectedPeriod uint32) {

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -50,7 +50,7 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 	t.Log("✅ - Queued validator OK", "id", id2.String())
 
 	block := config.ForkBlock + config.TransitionPeriod
-	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
+	assertValidatorStatusWithSigner(t, staker, validator1PoA, id1, builtin.StakerStatusActive, block)
 	assertValidatorStatusWithSigner(t, staker, validator2PoA, id2, builtin.StakerStatusActive, block)
 
 	id3 := addValidator(t, staker, validator1NonPoA, false, config.MinStakingPeriod)

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -51,6 +51,7 @@ func TestHayabusaAddNonPoAValidator(t *testing.T) {
 
 	block := config.ForkBlock + config.TransitionPeriod
 	assertValidatorStatus(t, staker, id1, builtin.StakerStatusActive, block)
+	block += config.MinStakingPeriod
 	assertValidatorStatus(t, staker, id2, builtin.StakerStatusActive, block)
 
 	id3 := addValidator(t, staker, validator1NonPoA, false, config.MinStakingPeriod)

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -668,36 +668,7 @@ func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID tho
 	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
-	if validator.Status == builtin.StakerStatusUnknown {
-		slog.Info("❌ - validator status unknown, retrying for up to 2 minutes",
-			"validatorID", validatorID.String(),
-			"status", validator.Status,
-			"master", validator.Master,
-			"endorsor", validator.Endorsor,
-			"stake", validator.Stake,
-			"autoRenew", validator.AutoRenew,
-			"online", validator.Online,
-			"BLOCK", waitForBlock,
-		)
-
-		ticker := utils.NewTicker(staker.Raw().Client())
-		err := ticker.WaitForCondition(2*time.Minute, func() (bool, error) {
-			validator, err := staker.Get(validatorID)
-			if err != nil {
-				return false, err
-			}
-			if validator.Status != builtin.StakerStatusUnknown {
-				slog.Info("✅ - validator status changed from unknown",
-					"validatorID", validatorID.String(),
-					"newStatus", validator.Status,
-				)
-				return true, nil
-			}
-			return false, nil
-		})
-		assert.NoError(t, err, "Validator %s status remained unknown after 2 minutes", validatorID.String())
-	}
-	assert.Equal(t, expectedStatus, validator.Status)
+	assert.Equal(t, expectedStatus, validator.Status, "validatorID", validatorID.String())
 }
 
 func assertValidatorStakingPeriod(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes32, expectedPeriod uint32) {

--- a/tests/validations/validations_test.go
+++ b/tests/validations/validations_test.go
@@ -668,8 +668,7 @@ func validatorWithdraw(t *testing.T, staker *builtin.Staker, signer bind.Signer,
 }
 
 func assertValidatorStatus(t *testing.T, staker *builtin.Staker, validatorID thor.Bytes32, expectedStatus builtin.StakerStatus, waitForBlock uint32) {
-	ticker := utils.NewTicker(staker.Raw().Client())
-	assert.NoError(t, ticker.WaitForBlock(waitForBlock))
+	assert.NoError(t, utils.NewTicker(staker.Raw().Client()).WaitForBlock(waitForBlock))
 	validator, err := staker.Get(validatorID)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedStatus, validator.Status)

--- a/testutil/retry.go
+++ b/testutil/retry.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,44 +14,6 @@ type StakerStatusUnknownError struct {
 
 func (e StakerStatusUnknownError) Error() string {
 	return fmt.Sprintf("validator status is unknown for validation ID: %s", e.ValidationID)
-}
-
-func IsStakerStatusUnknownError(err error) bool {
-	var statusErr StakerStatusUnknownError
-	return errors.As(err, &statusErr)
-}
-
-func RetryOnStakerStatusUnknown(t *testing.T, maxRetries int, fn func() error) {
-	var lastErr error
-	delay := 2 * time.Second
-	backoff := 1.5
-
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		if attempt > 1 {
-			t.Logf("🔄 Retrying due to StakerStatusUnknown (attempt %d/%d, delay: %v)", attempt, maxRetries, delay)
-			time.Sleep(delay)
-			delay = time.Duration(float64(delay) * backoff)
-		}
-
-		if err := fn(); err != nil {
-			lastErr = err
-
-			if IsStakerStatusUnknownError(err) {
-				t.Logf("❌ Attempt %d failed with StakerStatusUnknown: %v", attempt, err)
-				continue
-			} else {
-				t.Logf("❌ Attempt %d failed with non-retryable error: %v", attempt, err)
-				t.Fatalf("Non-retryable error: %v", err)
-			}
-		}
-
-		if attempt > 1 {
-			t.Logf("✅ Operation successful on attempt %d", attempt)
-		}
-		return
-	}
-
-	t.Fatalf("❌ Operation failed after %d attempts. Last error: %v", maxRetries, lastErr)
 }
 
 func RunTestWithRetry(t *testing.T, maxRetries int, testFunc func() error) {

--- a/testutil/retry.go
+++ b/testutil/retry.go
@@ -1,0 +1,87 @@
+package testutil
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// StakerStatusUnknownError is returned when the validator status is unknown
+// This is usually due to a fork, and we need to retry the test
+type StakerStatusUnknownError struct {
+	ValidationID string
+}
+
+func (e StakerStatusUnknownError) Error() string {
+	return fmt.Sprintf("validator status is unknown for validation ID: %s", e.ValidationID)
+}
+
+func IsStakerStatusUnknownError(err error) bool {
+	var statusErr StakerStatusUnknownError
+	return errors.As(err, &statusErr)
+}
+
+func RetryOnStakerStatusUnknown(t *testing.T, maxRetries int, fn func() error) {
+	var lastErr error
+	delay := 2 * time.Second
+	backoff := 1.5
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if attempt > 1 {
+			t.Logf("🔄 Retrying due to StakerStatusUnknown (attempt %d/%d, delay: %v)", attempt, maxRetries, delay)
+			time.Sleep(delay)
+			delay = time.Duration(float64(delay) * backoff)
+		}
+
+		if err := fn(); err != nil {
+			lastErr = err
+
+			if IsStakerStatusUnknownError(err) {
+				t.Logf("❌ Attempt %d failed with StakerStatusUnknown: %v", attempt, err)
+				continue
+			} else {
+				t.Logf("❌ Attempt %d failed with non-retryable error: %v", attempt, err)
+				t.Fatalf("Non-retryable error: %v", err)
+			}
+		}
+
+		if attempt > 1 {
+			t.Logf("✅ Operation successful on attempt %d", attempt)
+		}
+		return
+	}
+
+	t.Fatalf("❌ Operation failed after %d attempts. Last error: %v", maxRetries, lastErr)
+}
+
+func RunTestWithRetry(t *testing.T, maxRetries int, testFunc func() error) {
+	var lastErr error
+	delay := 3 * time.Second
+	backoff := 2.0
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if attempt > 1 {
+			t.Logf("🔄 Retrying complete test from the beginning (attempt %d/%d, delay: %v)", attempt, maxRetries, delay)
+			time.Sleep(delay)
+			delay = time.Duration(float64(delay) * backoff)
+		}
+
+		if err := testFunc(); err != nil {
+			lastErr = err
+			t.Logf("❌ Attempt %d of complete test failed: %v", attempt, err)
+			continue
+		}
+
+		if attempt > 1 {
+			t.Logf("✅ Complete test successful on attempt %d", attempt)
+		}
+		return
+	}
+
+	t.Fatalf("❌ Complete test failed after %d attempts. Last error: %v", maxRetries, lastErr)
+}
+
+func RunFlakyTest(t *testing.T, testFunc func() error) {
+	RunTestWithRetry(t, 3, testFunc)
+}

--- a/utils/staker.go
+++ b/utils/staker.go
@@ -9,7 +9,9 @@ import (
 )
 
 func WaitForPOS(staker *builtin.Staker, maxBlock uint32) error {
-	return WaitForCondition(staker.Raw().Client(), maxBlock, func() (bool, error) {
+	// Wait for PoS to be active, regardless of the specific block
+	// This handles cases where forks cause PoS to activate later than expected
+	return WaitForCondition(staker.Raw().Client(), maxBlock+20, func() (bool, error) {
 		_, id, err := staker.FirstActive()
 		return err == nil && !id.IsZero(), nil
 	})

--- a/utils/staker.go
+++ b/utils/staker.go
@@ -9,7 +9,7 @@ import (
 )
 
 func WaitForPOS(staker *builtin.Staker, maxBlock uint32) error {
-	return WaitForCondition(staker.Raw().Client(), maxBlock+20, func() (bool, error) {
+	return WaitForCondition(staker.Raw().Client(), maxBlock, func() (bool, error) {
 		_, id, err := staker.FirstActive()
 		return err == nil && !id.IsZero(), nil
 	})

--- a/utils/staker.go
+++ b/utils/staker.go
@@ -9,8 +9,6 @@ import (
 )
 
 func WaitForPOS(staker *builtin.Staker, maxBlock uint32) error {
-	// Wait for PoS to be active, regardless of the specific block
-	// This handles cases where forks cause PoS to activate later than expected
 	return WaitForCondition(staker.Raw().Client(), maxBlock+20, func() (bool, error) {
 		_, id, err := staker.FirstActive()
 		return err == nil && !id.IsZero(), nil

--- a/utils/staker.go
+++ b/utils/staker.go
@@ -2,8 +2,11 @@ package utils
 
 import (
 	"errors"
+	"log/slog"
+	"testing"
 	"time"
 
+	"github.com/vechain/networkhub/network/node"
 	"github.com/vechain/thor/v2/thorclient"
 	"github.com/vechain/thor/v2/thorclient/builtin"
 )
@@ -43,5 +46,57 @@ func WaitForCondition(client *thorclient.Client, maxBlock uint32, condition func
 			return errors.New("condition not met, max block reached")
 		}
 		time.Sleep(1 * time.Second)
+	}
+}
+
+// WaitForPeersConnection waits for all nodes to connect to each other
+func WaitForPeersConnection(t *testing.T, nodes []node.Config, expectedPeersLen int) error {
+	// Timeout configuration
+	timeout := 5 * time.Minute
+	timeoutChan := time.After(timeout)
+	tick := time.NewTicker(5 * time.Second)
+	defer tick.Stop()
+	attempts := 0
+
+	slog.Info("waiting for peers to connect...", "expected_peers", expectedPeersLen, "timeout", timeout.Seconds())
+
+	for {
+		select {
+		case <-timeoutChan:
+			// Log detailed information before failing
+			for i, node := range nodes {
+				c := thorclient.New(node.GetHTTPAddr())
+				peers, err := c.Peers()
+				if err != nil {
+					slog.Error("failed to get peers", "node", i, "error", err)
+				} else {
+					slog.Error("node peer count", "node", i, "peers", len(peers), "expected", expectedPeersLen)
+				}
+			}
+			return errors.New("timed out waiting for nodes to connect")
+
+		case <-tick.C:
+			attempts++
+			allConnected := true
+
+			for i, node := range nodes {
+				c := thorclient.New(node.GetHTTPAddr())
+				peers, err := c.Peers()
+				if err != nil {
+					slog.Warn("failed to get peers", "attempt", attempts, "node", i, "error", err)
+					allConnected = false
+					break
+				}
+				if len(peers) != expectedPeersLen {
+					slog.Warn("incorrect peer count", "attempt", attempts, "node", i, "peers", len(peers), "expected", expectedPeersLen)
+					allConnected = false
+					break
+				}
+			}
+			if allConnected {
+				slog.Info("all nodes connected successfully", "attempts", attempts)
+				return nil
+			}
+		}
 	}
 }

--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strconv"
+	"testing"
 	"time"
 
+	"github.com/vechain/networkhub/network/node"
 	"github.com/vechain/thor/v2/thorclient"
 
 	"github.com/vechain/thor/v2/api/blocks"
@@ -102,6 +105,67 @@ func (t *Ticker) WaitForCondition(timeout time.Duration, conditionalFunc Conditi
 				return nil
 			}
 			time.Sleep(10 * time.Second)
+		}
+	}
+}
+
+// WaitForPeersConnection waits for all nodes to connect to each other
+func WaitForPeersConnection(t *testing.T, nodes []node.Config, expectedPeersLen int) []*thorclient.Client {
+	// Timeout configuration
+	timeout := 5 * time.Minute
+	if os.Getenv("CI") == "true" {
+		timeout = 10 * time.Minute // Longer timeout for CI
+	}
+
+	timeoutChan := time.After(timeout)
+	tick := time.NewTicker(5 * time.Second)
+	defer tick.Stop()
+
+	clients := make([]*thorclient.Client, 0)
+	attempts := 0
+
+	slog.Info("waiting for peers to connect...", "expected_peers", expectedPeersLen, "timeout", timeout.Seconds())
+
+	for {
+		select {
+		case <-timeoutChan:
+			// Log detailed information before failing
+			for i, node := range nodes {
+				c := thorclient.New(node.GetHTTPAddr())
+				peers, err := c.Peers()
+				if err != nil {
+					slog.Error("failed to get peers", "node", i, "error", err)
+				} else {
+					slog.Error("node peer count", "node", i, "peers", len(peers), "expected", expectedPeersLen)
+				}
+			}
+			t.Fatal("timed out waiting for nodes to connect")
+
+		case <-tick.C:
+			attempts++
+			allConnected := true
+
+			for i, node := range nodes {
+				c := thorclient.New(node.GetHTTPAddr())
+				peers, err := c.Peers()
+				if err != nil {
+					slog.Warn("failed to get peers", "attempt", attempts, "node", i, "error", err)
+					allConnected = false
+					clients = clients[:0]
+					break
+				}
+				if len(peers) != expectedPeersLen {
+					slog.Warn("incorrect peer count", "attempt", attempts, "node", i, "peers", len(peers), "expected", expectedPeersLen)
+					allConnected = false
+					clients = clients[:0]
+					break
+				}
+				clients = append(clients, c)
+			}
+			if allConnected {
+				slog.Info("all nodes connected successfully", "attempts", attempts)
+				return clients
+			}
 		}
 	}
 }

--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -113,7 +113,6 @@ func (t *Ticker) WaitForCondition(timeout time.Duration, conditionalFunc Conditi
 func WaitForPeersConnection(t *testing.T, nodes []node.Config, expectedPeersLen int) []*thorclient.Client {
 	// Timeout configuration
 	timeout := 5 * time.Minute
-
 	timeoutChan := time.After(timeout)
 	tick := time.NewTicker(5 * time.Second)
 	defer tick.Stop()

--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -113,9 +113,6 @@ func (t *Ticker) WaitForCondition(timeout time.Duration, conditionalFunc Conditi
 func WaitForPeersConnection(t *testing.T, nodes []node.Config, expectedPeersLen int) []*thorclient.Client {
 	// Timeout configuration
 	timeout := 5 * time.Minute
-	if os.Getenv("CI") == "true" {
-		timeout = 10 * time.Minute // Longer timeout for CI
-	}
 
 	timeoutChan := time.After(timeout)
 	tick := time.NewTicker(5 * time.Second)

--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -92,7 +92,7 @@ func (t *Ticker) WaitForCondition(timeout time.Duration, conditionalFunc Conditi
 	for {
 		select {
 		case <-ticker.C:
-			return errors.New("timeout waiting for block")
+			return errors.New("timeout waiting for condition")
 		default:
 			resp, err := conditionalFunc()
 			if err != nil {

--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -4,12 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"strconv"
-	"testing"
 	"time"
 
-	"github.com/vechain/networkhub/network/node"
 	"github.com/vechain/thor/v2/thorclient"
 
 	"github.com/vechain/thor/v2/api/blocks"
@@ -105,63 +102,6 @@ func (t *Ticker) WaitForCondition(timeout time.Duration, conditionalFunc Conditi
 				return nil
 			}
 			time.Sleep(10 * time.Second)
-		}
-	}
-}
-
-// WaitForPeersConnection waits for all nodes to connect to each other
-func WaitForPeersConnection(t *testing.T, nodes []node.Config, expectedPeersLen int) []*thorclient.Client {
-	// Timeout configuration
-	timeout := 5 * time.Minute
-	timeoutChan := time.After(timeout)
-	tick := time.NewTicker(5 * time.Second)
-	defer tick.Stop()
-
-	clients := make([]*thorclient.Client, 0)
-	attempts := 0
-
-	slog.Info("waiting for peers to connect...", "expected_peers", expectedPeersLen, "timeout", timeout.Seconds())
-
-	for {
-		select {
-		case <-timeoutChan:
-			// Log detailed information before failing
-			for i, node := range nodes {
-				c := thorclient.New(node.GetHTTPAddr())
-				peers, err := c.Peers()
-				if err != nil {
-					slog.Error("failed to get peers", "node", i, "error", err)
-				} else {
-					slog.Error("node peer count", "node", i, "peers", len(peers), "expected", expectedPeersLen)
-				}
-			}
-			t.Fatal("timed out waiting for nodes to connect")
-
-		case <-tick.C:
-			attempts++
-			allConnected := true
-
-			for i, node := range nodes {
-				c := thorclient.New(node.GetHTTPAddr())
-				peers, err := c.Peers()
-				if err != nil {
-					slog.Warn("failed to get peers", "attempt", attempts, "node", i, "error", err)
-					allConnected = false
-					clients = clients[:0]
-					break
-				}
-				if len(peers) != expectedPeersLen {
-					slog.Warn("incorrect peer count", "attempt", attempts, "node", i, "peers", len(peers), "expected", expectedPeersLen)
-					allConnected = false
-					clients = clients[:0]
-					break
-				}
-				clients = append(clients, c)
-			}
-			if allConnected {
-				slog.Info("all nodes connected successfully", "attempts", attempts)
-				return clients
-			}
 		}
 	}
 }


### PR DESCRIPTION
The core error for the tests is produced by the forks:

```
2025-06-30T16:04:55.4356890Z [Test_Stargate_SingleDelegator-Node-0] WARN [06-30|16:04:55.432] "⑂⑂⑂⑂⑂⑂⑂⑂ FORK HAPPENED ⑂⑂⑂⑂⑂⑂⑂⑂\nside-chain count: 2" pkg=node
2025-06-30T16:04:55.4357855Z [Test_Stargate_SingleDelegator-Node-0] WARN [06-30|16:04:55.432] "side-chain[0]: ID=0x0000000158c26f86b2cd4e317faf2771c1d8ef4225bd7377000d73593f7236ee, Block=1" pkg=node
2025-06-30T16:04:55.4358970Z [Test_Stargate_SingleDelegator-Node-0] WARN [06-30|16:04:55.432] "side-chain[1]: ID=0x000000023f6c5a00e72b13ff5d5d2c02d8d85902243abcb543c55a8463ca469a, Block=2" pkg=node
```

When something like this happens, stuff like the addition of validators cannot be recognised properly sometimes no matter how long we wait for them to have a certain condition. The test will fail because their status will remain `unknown`.

This PR addresses this problem by retrying those tests with errors ONLY for the case of that `unknown` status + the actual flakiness of the particular condition.

The idea of this approach comes from the assumption that only the code of this repo is completely under our control. Both self-hosted runners referred to in the code (`large` and `xlarge`) have been tested with the forks causing flakiness regardless (even though `xlarge` has 32 vCPUs and 64 GiB memory). These errors normally do not happen locally.

Features added:

- The tests only start when the expected peers are connected (approach extracted from `networkhub`)
- Dynamic port allocation, randomly first and sequentially in case of error
- Retry mechanism for those tests identified as flaky
- Added test ID to the logs so we can identify easier the node we are looking at

Re-run the job 4 times over the last commit before code review with all green every time: https://github.com/vechain/hayabusa-e2e/actions/runs/15978053074.

Closes https://github.com/vechain/protocol-board-repo/issues/636