### PR TITLE
chore(delegations): reduced execution times

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,7 +3,7 @@ name: Run Hayabusa Tests
 on:
   push:
     branches:
-      - main
+      - chore/reduce-delegation-times
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,7 +3,7 @@ name: Run Hayabusa Tests
 on:
   push:
     branches:
-      - chore/reduce-delegation-times
+      - main
   pull_request:
   workflow_dispatch:
     inputs:

--- a/hayabusa/hayabusa.go
+++ b/hayabusa/hayabusa.go
@@ -348,7 +348,7 @@ func cleanupPorts(ports []int) {
 
 // isPortAvailable checks if a port is actually available for binding
 func isPortAvailable(port int) bool {
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return false

--- a/tests/delegations/delegations_test.go
+++ b/tests/delegations/delegations_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func Test_StargateRewards(t *testing.T) {
-	// Setup
+	t.Parallel()
 	staker, config, validationIDs := newDelegationSetup(t)
 
 	expectedStake := new(big.Int).Mul(builtin.MinStake(), big.NewInt(int64(len(validationIDs))))
@@ -77,6 +77,7 @@ func Test_StargateRewards(t *testing.T) {
 }
 
 func Test_Delegations_Delegate1PeriodOnly(t *testing.T) {
+	t.Parallel()
 	staker, config, validationIDs := newDelegationSetup(t)
 	ticker := utils.NewTicker(staker.Raw().Client())
 


### PR DESCRIPTION
Reduced from roughly 10 minutes and a half to 8 minutes and a half by parallelising the tests.

Consistent execution tested in this sequence of runs https://github.com/vechain/hayabusa-e2e/actions/runs/16200850741.

Also fixed port availability checking.