### PR TITLE
fix evcition test

### DIFF
--- a/tests/eviction/eviction_test.go
+++ b/tests/eviction/eviction_test.go
@@ -90,7 +90,7 @@ func TestHayabusaEviction(t *testing.T) {
 	})
 
 	offlineBlock := config.ForkBlock + config.TransitionPeriod
-	exitBlock := offlineBlock + (config.EpochLength + thor.ValidatorEvictionThreshold()) + 1
+	exitBlock := offlineBlock + (config.EpochLength + config.ValidatorEvictionThreshold) + 1
 	ticker := utils.NewTicker(staker.Raw().Client())
 	t.Log("✅ waiting for block", exitBlock)
 	require.NoError(t, ticker.WaitForBlock(exitBlock))


### PR DESCRIPTION
thor.ValidatorEvictionThreshold() will only return the default value, which makes eviction test takes too long time.